### PR TITLE
Fix checksum when filename contains spaces and fix Linux-style checksum

### DIFF
--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -61,7 +61,7 @@ func shaSum(sf shaFunc, algo string, files []string, w io.Writer, bsdFormat bool
 			fmt.Fprintf(w, "%s (%s) = %s\n", algo, files[i], hash)
 		} else {
 			// Linux-style output
-			fmt.Fprintf(w, "%s  %s\n", files[i], hash)
+			fmt.Fprintf(w, "%s  %s\n", hash, files[i])
 		}
 	}
 	return nil

--- a/signify/signify_test.go
+++ b/signify/signify_test.go
@@ -139,7 +139,7 @@ func testChecksum(bsdStyle bool) error {
 	}
 	//defer os.RemoveAll(tmpdir)
 	// create test files
-	filenames := []string{"a.txt", "b.txt", "c.txt"}
+	filenames := []string{"a.txt", "b.txt", "c.txt", "with spaces.txt"}
 	var files []string
 	for i := 0; i < len(filenames); i++ {
 		files = append(files, filepath.Join(tmpdir, filenames[i]))


### PR DESCRIPTION
The `-C` option fails when a checksum file has filenames containing spaces. In addition, the filename and hash were reversed in the code for Linux-style checksums.

This patch replaces the use of `fmt.Sscanf` with the `regexp` module for parsing checksum lines, and fixes the ordering for Linux-style checksums.